### PR TITLE
GCC build fixes (incomplete)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.2)
 SET( CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules"
                        "${CMAKE_MODULE_PATH}" )
 
@@ -65,7 +65,8 @@ SET (FRONTIER_ENGINE_LIBS
 target_include_directories ( Frontier.Engine PUBLIC
     ${FRONTIER_ENGINE_INCLUDES}
 )
-
+target_compile_features ( Frontier.Engine PRIVATE cxx_static_assert
+    cxx_auto_type )
 
 # Testing
 option(gtest_force_shared_crt "Use shared (DLL) run-time lib even when Google Test is built as static lib." ON)

--- a/Source/Event/Input/FTInputManager.h
+++ b/Source/Event/Input/FTInputManager.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <vector>
 #include <GL/glew.h>
 #include <ThirdParty/Signals/Signal.h>
 #include <Frontier.h>

--- a/Source/Rendering/Mesh/FTIndexedMesh.h
+++ b/Source/Rendering/Mesh/FTIndexedMesh.h
@@ -9,11 +9,11 @@ public:
 
     }
 
-    FTIndexedMeshData(size_t vertexCount, size_t indexCount) : FTMeshData(vertexCount), index_count_(0) {
+    FTIndexedMeshData(size_t vertexCount, size_t indexCount) : FTMeshData<VertexType>(vertexCount), index_count_(0) {
         indices_.reserve(indexCount);
     }
 
-    FTIndexedMeshData(std::vector<VertexType>& vertices, std::vector<IndexType>& indices) : FTMeshData(vertices), index_count_(0) {
+    FTIndexedMeshData(std::vector<VertexType>& vertices, std::vector<IndexType>& indices) : FTMeshData<VertexType>(vertices), index_count_(0) {
         indices_ = std::move(indices);
     }
 
@@ -62,7 +62,7 @@ public:
 
         if (cleanup) {
             glBindVertexArray(0);
-            is_loaded_ = true;
+            this->is_loaded_ = true;
         }
     }
 
@@ -79,7 +79,7 @@ public:
 
         if (cleanup) {
             glBindVertexArray(0);
-            is_loaded_ = true;
+            this->is_loaded_ = true;
         }
     }
 
@@ -118,14 +118,14 @@ protected:
 
 private:
     virtual void loadMeshData(FTMeshData<VertexType>* data, bool is_static, bool cleanup) override {
-        FTMesh::loadMeshData(data, is_static, cleanup);
+        FTMesh<ShaderProgram,VertexType>::loadMeshData(data, is_static, cleanup);
     }
 
     virtual void setMeshData(FTMeshData<VertexType>* data) override {
-        FTMesh::setMeshData(data);
+        FTMesh<ShaderProgram,VertexType>::setMeshData(data);
     }
 
     virtual void loadEmptyMesh(GLuint vertex_count, bool cleanup) override {
-        FTMesh::loadEmptyMesh(vertex_count, cleanup);
+        FTMesh<ShaderProgram,VertexType>::loadEmptyMesh(vertex_count, cleanup);
     }
 };

--- a/Source/Rendering/Mesh/FTIndexedTexturedMesh.h
+++ b/Source/Rendering/Mesh/FTIndexedTexturedMesh.h
@@ -4,8 +4,11 @@
 
 template <typename ShaderProgram, typename VertexType, typename IndexType>
 class FTIndexedTexturedMesh : public FTIndexedMesh<ShaderProgram, VertexType, IndexType> {
+private:
+    typedef FTIndexedMesh<ShaderProgram, VertexType, IndexType> FTIndexedMeshBase_;
+
 public:
-    FTIndexedTexturedMesh() : FTIndexedMesh() {
+    FTIndexedTexturedMesh() : FTIndexedMeshBase_() {
 
     }
 
@@ -20,8 +23,8 @@ public:
     void draw() override {
         glActiveTexture(GL_TEXTURE0);
         glBindTexture(GL_TEXTURE_2D, texture_->getTextureId());
-        glUniform1i(current_shader_program_->getTextureUniformId(), 0);
-        FTIndexedMesh::draw();
+        glUniform1i(this->current_shader_program_->getTextureUniformId(), 0);
+        FTIndexedMeshBase_::draw();
     }
 
 protected:

--- a/Source/Rendering/Scene/Action/FTActionManager.h
+++ b/Source/Rendering/Scene/Action/FTActionManager.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <Frontier.h>
 #include <unordered_map>
+#include <vector>
 #include <Event/Engine/FTEngineEvents.h>
 
 class FTNode;

--- a/Source/Rendering/Text/FTFontCache.h
+++ b/Source/Rendering/Text/FTFontCache.h
@@ -14,7 +14,7 @@ public:
             loadFont(string);
             it = loaded_fonts_.find(string);
         }
-        FTAssert(it != loaded_fonts_.end(), "Could not find Font %s", string);
+        FTAssert(it != loaded_fonts_.end(), "Could not find Font %s", string.c_str());
         return it->second;
     }
 

--- a/Source/Rendering/Textures/FTTextureDDS.cpp
+++ b/Source/Rendering/Textures/FTTextureDDS.cpp
@@ -20,13 +20,13 @@ GLuint FTTextureDDS::loadDDS(const std::string& provided_path) {
     unsigned char header[124];
 
     auto imagepath = FTEngine::getFileManager()->getPathToFile(provided_path);
-    FTAssert(imagepath != "", "File %s not found", provided_path);
+    FTAssert(imagepath != "", "File %s not found", provided_path.c_str());
 
     FILE* fp;
 
     /* try to open the file */
     auto err = fopen_s(&fp, imagepath.c_str(), "rb");
-    FTAssert(err == 0, "File %s could not be opened!", imagepath);
+    FTAssert(err == 0, "File %s could not be opened!", imagepath.c_str());
 
 
     /* verify the type of file */

--- a/Source/Rendering/Textures/FTTextureDDS.cpp
+++ b/Source/Rendering/Textures/FTTextureDDS.cpp
@@ -2,6 +2,7 @@
 #include <FTEngine.h>
 #include <Util/FTFileManager.h>
 
+#include <string.h> // for strncmp
 
 FTTextureDDS::FTTextureDDS(const std::string& filename) {
     texture_id_ = loadDDS(filename);

--- a/Source/Rendering/Textures/FTTextureDDS.cpp
+++ b/Source/Rendering/Textures/FTTextureDDS.cpp
@@ -16,6 +16,11 @@ FTTextureDDS::~FTTextureDDS() {
 #define FOURCC_DXT3 0x33545844 // Equivalent to "DXT3" in ASCII
 #define FOURCC_DXT5 0x35545844 // Equivalent to "DXT5" in ASCII
 
+/* HACK: no fopen_s on non-Windows systems */
+#ifndef WIN32
+#   define fopen_s(pFile,filename,mode) ((*(pFile))=fopen((filename),(mode)))==NULL
+#endif
+
 // Code from http://www.opengl-tutorial.org/beginners-tutorials/tutorial-5-a-textured-cube/
 GLuint FTTextureDDS::loadDDS(const std::string& provided_path) {
     unsigned char header[124];

--- a/Source/Util/FTAlignedData.h
+++ b/Source/Util/FTAlignedData.h
@@ -6,14 +6,25 @@ template <typename T>
 class FTAlignedData {
 public:
     FTAlignedData() {
+#if (__STDC_VERSION__ >= 201112L) || _ISOC11_SOURCE
+        // if we're C11, use the standard aligned alloc function
+        void* ptr = aligned_alloc(16, sizeof(T));
+#else
         void* ptr = _aligned_malloc(sizeof(T), 16);
+#endif
         aligned_data_ = new(ptr)T();
         //*aligned_data_ = T();
     }
 
     ~FTAlignedData() {
         aligned_data_->~T();
+#if (__STDC_VERSION__ >= 201112L) || _ISOC11_SOURCE
+        // if we're C11, use the standard free function since we used
+        // aligned_alloc to allocate the data
+        free(aligned_data_);
+#else
         _aligned_free(aligned_data_);
+#endif
     }
 
     const T& getConstData() const {

--- a/Source/Util/FTAssert.h
+++ b/Source/Util/FTAssert.h
@@ -17,9 +17,9 @@ private:
     std::string msg_;
 };
 
-#define FTAssert(value, format, ...) if (!(value)) { \
+#define FTAssert(value, ...) if (!(value)) { \
     FTLogPrint("", false, "Assertion failed with error: "); \
-    FTLogPrint("", false, format, __VA_ARGS__); \
+    FTLogPrint("", false, __VA_ARGS__); \
     FTLogPrint("", true, " at %s:%i",__FILE__, __LINE__); \
     throw FTException("Failed FTAssert"); \
 }

--- a/Source/Util/FTLog.cpp
+++ b/Source/Util/FTLog.cpp
@@ -6,6 +6,8 @@
 
 #ifdef WIN32
 #include <Windows.h>
+#endif
+
 #include <mutex>
 
 // This is to prevent corruption when printing from multiple threads
@@ -16,7 +18,7 @@ void FTLogPrint(const char* prefix, bool print_new_line, const char* format, ...
     va_list args;
     va_start(args, format);
     log_mutex.lock();
-#ifdef USE_VS_CONSOLE
+#if defined(USE_VS_CONSOLE) && defined(WIN32)
 
 
     _vsnprintf_s(log_buffer, sizeof(log_buffer), LOG_BUFFER_SIZE, format, args);
@@ -27,7 +29,7 @@ void FTLogPrint(const char* prefix, bool print_new_line, const char* format, ...
         OutputDebugStringA("\n");
 
 #else
-    printf(prefix);
+    printf("%s", prefix);
 	vprintf(format, args);
     if (print_new_line)
 	    printf("\n");
@@ -35,4 +37,3 @@ void FTLogPrint(const char* prefix, bool print_new_line, const char* format, ...
     log_mutex.unlock();
     va_end(args);
 }
-#endif

--- a/Source/Util/FTLog.h
+++ b/Source/Util/FTLog.h
@@ -1,10 +1,10 @@
 #include <stdarg.h>
 
-#define FTLog(format, ...) FTLogPrint("Info: ", true, format, __VA_ARGS__);
+#define FTLog(...) FTLogPrint("Info: ", true, __VA_ARGS__);
 
-#define FTLogWarn(format, ...) FTLogPrint("Warning: ", true, format, __VA_ARGS__);
+#define FTLogWarn(...) FTLogPrint("Warning: ", true, __VA_ARGS__);
 
-#define FTLogError(format, ...) FTLogPrint("Error: ", true, format, __VA_ARGS__);
+#define FTLogError(...) FTLogPrint("Error: ", true, __VA_ARGS__);
 
 #define FTLOG(...) FTLog(__VA_ARGS__)
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -35,6 +35,8 @@ target_link_libraries(Frontier.Engine.Tests
 
 # Move back into Frontier.Engine directory within Visual Studio
 set_target_properties(Frontier.Engine.Tests PROPERTIES FOLDER Frontier.Engine)
+target_compile_features ( Frontier.Engine.Tests PRIVATE cxx_static_assert
+    cxx_auto_type )
 
 add_custom_command(TARGET Frontier.Engine.Tests POST_BUILD
                    COMMAND ${CMAKE_COMMAND} -E copy_directory

--- a/Tests/Source/Mock/MockLoader.cpp
+++ b/Tests/Source/Mock/MockLoader.cpp
@@ -2,6 +2,17 @@
 #include <FTEngine.h>
 #include <glfwmock.h>
 
+#if __cplusplus < 201402L
+// no make_unique support
+namespace std {
+    template<typename T, typename ...Args>
+    std::unique_ptr<T> make_unique( Args&& ...args )
+    {
+            return std::unique_ptr<T>( new T( std::forward<Args>(args)... ) );
+    }
+}
+#endif
+
 MockLoader::MockLoader() {
     mock_ = std::make_unique<GlfwMock>();
     FTEngine::init();

--- a/Tests/Source/Rendering/Camera/TestCamera.cpp
+++ b/Tests/Source/Rendering/Camera/TestCamera.cpp
@@ -5,6 +5,17 @@
 #include <Rendering/Camera/FTCamera3D.h>
 #include <Mock/ExpectUtils.h>
 
+#if __cplusplus < 201402L
+// no make_unique support
+namespace std {
+    template<typename T, typename ...Args>
+    std::unique_ptr<T> make_unique( Args&& ...args )
+    {
+            return std::unique_ptr<T>( new T( std::forward<Args>(args)... ) );
+    }
+}
+#endif
+
 TEST(TestCamera, TestRaycast2D) {
     GlfwMock mock;
     FTEngine::setup(true); {

--- a/Tests/Source/Rendering/Scene/TestActionManager.cpp
+++ b/Tests/Source/Rendering/Scene/TestActionManager.cpp
@@ -8,6 +8,17 @@
 #include <Rendering/Scene/FTScene.h>
 #include <Mock/MockAction.h>
 
+#if __cplusplus < 201402L
+// no make_unique support
+namespace std {
+    template<typename T, typename ...Args>
+    std::unique_ptr<T> make_unique( Args&& ...args )
+    {
+            return std::unique_ptr<T>( new T( std::forward<Args>(args)... ) );
+    }
+}
+#endif
+
 TEST(TestActionManager, TestAddRemove) {
     MockLoader loader;
    

--- a/Tests/Source/Rendering/Scene/TestActionSequence.cpp
+++ b/Tests/Source/Rendering/Scene/TestActionSequence.cpp
@@ -6,6 +6,17 @@
 #include <Rendering/Scene/FTView.h>
 #include <Rendering/Scene/FTScene.h>
 
+#if __cplusplus < 201402L
+// no make_unique support
+namespace std {
+    template<typename T, typename ...Args>
+    std::unique_ptr<T> make_unique( Args&& ...args )
+    {
+            return std::unique_ptr<T>( new T( std::forward<Args>(args)... ) );
+    }
+}
+#endif
+
 TEST(TestActionSequence, TestSimple) {
     MockLoader loader;
     auto engine_event_dispatcher = loader.getMockEngineEventDispatcher();

--- a/Tests/Source/Rendering/Scene/TestRepeatAction.cpp
+++ b/Tests/Source/Rendering/Scene/TestRepeatAction.cpp
@@ -5,6 +5,17 @@
 #include <Rendering/FTDirector.h>
 #include <Rendering/Scene/Action/FTRepeatAction.h>
 
+#if __cplusplus < 201402L
+// no make_unique support
+namespace std {
+    template<typename T, typename ...Args>
+    std::unique_ptr<T> make_unique( Args&& ...args )
+    {
+            return std::unique_ptr<T>( new T( std::forward<Args>(args)... ) );
+    }
+}
+#endif
+
 TEST(TestRepeatAction, TestSimple) {
     MockLoader loader;
     auto engine_event_dispatcher = loader.getMockEngineEventDispatcher();

--- a/Tests/Source/Rendering/Scene/TestTransform.cpp
+++ b/Tests/Source/Rendering/Scene/TestTransform.cpp
@@ -5,6 +5,16 @@
 #include <Frontier.h>
 #include <Mock/ExpectUtils.h>
 
+#if __cplusplus < 201402L
+// no make_unique support
+namespace std {
+    template<typename T, typename ...Args>
+    std::unique_ptr<T> make_unique( Args&& ...args )
+    {
+            return std::unique_ptr<T>( new T( std::forward<Args>(args)... ) );
+    }
+}
+#endif
 
 TEST(TestTransform, TestTranslate) {
 

--- a/Tests/Source/Rendering/Textures/TestTextureDDS.cpp
+++ b/Tests/Source/Rendering/Textures/TestTextureDDS.cpp
@@ -2,6 +2,17 @@
 #include <glfwmock.h>
 #include <FTEngine.h>
 
+#if __cplusplus < 201402L
+// no make_unique support
+namespace std {
+    template<typename T, typename ...Args>
+    std::unique_ptr<T> make_unique( Args&& ...args )
+    {
+            return std::unique_ptr<T>( new T( std::forward<Args>(args)... ) );
+    }
+}
+#endif
+
 using ::testing::_;
 TEST(TestTextureDDS, TestLoadTextureDDS) {
     GlfwMock mock;

--- a/ThirdParty/glmock/glewmock/glewmock.hpp
+++ b/ThirdParty/glmock/glewmock/glewmock.hpp
@@ -1,6 +1,6 @@
 #ifndef GLEWMOCK_H
 #define GLEWMOCK_H
-#include "gl/glew.h"
+#include "GL/glew.h"
 #include "gmock/gmock.h"
 #include "glewmock2.hpp"
 

--- a/ThirdParty/glmock/glewmock/glewmock2.cpp
+++ b/ThirdParty/glmock/glewmock/glewmock2.cpp
@@ -1,4 +1,5 @@
 #include "glewmock2.hpp"
+#include <stdexcept>
 
 
 GlewMock2::GlewMock2() {
@@ -28,7 +29,7 @@ void mockgl_GetProgramiv(GLuint program, GLenum pname, GLint* param) {
         *param = 0;
         break;
     default:
-        throw new std::exception("Unsupported GetProgramIV Enum");
+        throw new std::invalid_argument("Unsupported GetProgramIV Enum");
     }
 }
 
@@ -55,7 +56,7 @@ void mockgl_GetShaderiv(GLuint shader, GLenum pname, GLint* param) {
         *param = 0;
         break;
     default:
-        throw new std::exception("Unsupported GetShaderIV Enum");
+        throw new std::invalid_argument("Unsupported GetShaderIV Enum");
     }
 }
 

--- a/ThirdParty/glmock/glmock/CMakeLists.txt
+++ b/ThirdParty/glmock/glmock/CMakeLists.txt
@@ -8,3 +8,5 @@ target_include_directories(glmock PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/../../googletest/googlemock/include
     ${CMAKE_CURRENT_SOURCE_DIR}/../../glew/include
     ${CMAKE_CURRENT_SOURCE_DIR}/)
+
+target_compile_features(glmock PRIVATE cxx_thread_local)


### PR DESCRIPTION
This is an incomplete set of changes required to compile the Frontier engine on Linux. These are the changes I'm fairly certain won't break Windows although I've not tested this. There are a few hacks here but they should #if-away on Windows.

Some of these changes are likely to be due to MSVC being more flexible than the standard. Some are simple portability fixes. Each commit is stand alone and, I think, should be cherry-pick-able.
